### PR TITLE
Release bpf-tools v1.18

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -23,7 +23,7 @@ rm -rf out
 mkdir -p out
 pushd out
 
-git clone --single-branch --branch bpf-tools-v1.16 https://github.com/solana-labs/rust.git
+git clone --single-branch --branch bpf-tools-v1.18 https://github.com/solana-labs/rust.git
 echo "$( cd rust && git rev-parse HEAD )  https://github.com/solana-labs/rust.git" >> version.md
 
 git clone --single-branch --branch rust-1.54.0 https://github.com/rust-lang/cargo.git
@@ -38,7 +38,7 @@ OPENSSL_STATIC=1 cargo build --release
 popd
 
 if [[ "${HOST_TRIPLE}" != "x86_64-pc-windows-msvc" ]] ; then
-    git clone --single-branch --branch bpf-port https://github.com/solana-labs/newlib.git
+    git clone --single-branch --branch bpf-tools-v1.18 https://github.com/solana-labs/newlib.git
     echo "$( cd newlib && git rev-parse HEAD )  https://github.com/solana-labs/newlib.git" >> version.md
     mkdir -p newlib_build
     mkdir -p newlib_install


### PR DESCRIPTION
- Add fix for incorrect code generation that may lead for parts of a
function missing due to the incorrect replacement of loads by
compile-time constants.  This issue is reported here
https://github.com/solana-labs/solana/issues/20538