### PR TITLE
Bump platform tools to v1.49

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -65,10 +65,10 @@ rm -rf "${OUT_DIR}"
 mkdir -p "${OUT_DIR}"
 pushd "${OUT_DIR}"
 
-git clone --single-branch --branch solana-tools-v1.48 --recurse-submodules --shallow-submodules https://github.com/anza-xyz/rust.git
+git clone --single-branch --branch solana-tools-v1.49 --recurse-submodules --shallow-submodules https://github.com/anza-xyz/rust.git
 echo "$( cd rust && git rev-parse HEAD )  https://github.com/anza-xyz/rust.git" >> version.md
 
-git clone --single-branch --branch solana-tools-v1.48 https://github.com/anza-xyz/cargo.git
+git clone --single-branch --branch solana-tools-v1.49 https://github.com/anza-xyz/cargo.git
 echo "$( cd cargo && git rev-parse HEAD )  https://github.com/anza-xyz/cargo.git" >> version.md
 
 pushd rust
@@ -90,7 +90,7 @@ fi
 popd
 
 if [[ "${HOST_TRIPLE}" != "x86_64-pc-windows-msvc" ]] ; then
-    git clone --single-branch --branch solana-tools-v1.48 https://github.com/anza-xyz/newlib.git
+    git clone --single-branch --branch solana-tools-v1.49 https://github.com/anza-xyz/newlib.git
     echo "$( cd newlib && git rev-parse HEAD )  https://github.com/anza-xyz/newlib.git" >> version.md
 
     build_newlib "v0"


### PR DESCRIPTION
This version brings SBPFv4 so that we can run ABIv2 test in the monorepo CI.