### PR TITLE
build: Use nix for building rust and cargo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
     needs: check
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false # while testing
       matrix:
         include:
         - target: x86_64-unknown-linux-gnu
@@ -51,11 +52,6 @@ jobs:
           out_dir: /c/out
     steps:
     - uses: actions/checkout@v1
-    - name: Install coreutils and swig
-      run: |
-        brew update && brew install coreutils swig
-      if: matrix.tar == 'osx'
-      shell: bash
     - name: Free Disk Space (Ubuntu)
       uses: jlumbroso/free-disk-space@main
       if: matrix.os == 'ubuntu-22.04'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,45 +22,30 @@ jobs:
         - target: x86_64-unknown-linux-gnu
           arch: x86_64
           os: ubuntu-22.04
-          ninja_file: ninja-linux.zip
-          ninja_dir: /usr/local/bin
-          ninja_sudo: sudo
           rust: stable
           tar: linux
           out_dir: out
         - target: aarch64-unknown-linux-gnu
           arch: aarch64
           os: ubuntu-22.04-arm
-          ninja_file: ninja-linux-aarch64.zip
-          ninja_dir: /usr/local/bin
-          ninja_sudo: sudo
           rust: stable
           tar: linux
           out_dir: out
         - target: aarch64-apple-darwin
           arch: aarch64
           os: macos-latest
-          ninja_file: ninja-mac.zip
-          ninja_dir: /usr/local/bin
-          ninja_sudo: sudo
           rust: stable
           tar: osx
           out_dir: out
         - target: x86_64-apple-darwin
           arch: x86_64
           os: macos-15-intel
-          ninja_file: ninja-mac.zip
-          ninja_dir: /usr/local/bin
-          ninja_sudo: sudo
           rust: stable
           tar: osx
           out_dir: out
         - target: x86_64-pc-windows-msvc
           arch: x86_64
           os: windows-latest
-          ninja_file: ninja-win.zip
-          ninja_dir: /usr/bin
-          ninja_sudo:
           rust: stable
           tar: windows
           out_dir: /c/out
@@ -68,7 +53,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: Install coreutils and swig
       run: |
-        brew update && brew install coreutils swig ninja
+        brew update && brew install coreutils swig
       if: matrix.tar == 'osx'
       shell: bash
     - name: Free Disk Space (Ubuntu)
@@ -76,12 +61,29 @@ jobs:
       if: matrix.os == 'ubuntu-22.04'
       with:
         tool-cache: false
+    - name: Install Ninja
+      run: |
+        curl -L -O "https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-win.zip" && \
+        unzip -o ninja-win.zip -d /usr/bin && rm ninja-win.zip
+      if: matrix.tar == 'windows'
+      shell: bash
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: 1.89.0
+      if: matrix.tar == 'windows'
+    - name: Build
+      run: ./build.sh ${{ matrix.out_dir }}
+      shell: bash
+      if: matrix.tar == 'windows'
     - uses: cachix/install-nix-action@v31
       with:
         nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/871b9fd269ff6246794583ce4ee1031e1da71895.tar.gz
+      if: matrix.tar != 'windows'
     - name: Build
       run: ./build.sh --nix ${{ matrix.out_dir }}
       shell: bash
+      if: matrix.tar != 'windows'
     - name: Upload ${{ matrix.tar }} tarball
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,27 +71,16 @@ jobs:
         brew update && brew install coreutils swig ninja
       if: matrix.tar == 'osx'
       shell: bash
-    - name: Install Linux tools for LLDB
-      run: |
-        sudo apt-get install build-essential swig python3-dev libedit-dev libncurses5-dev libxml2-dev
-      if: matrix.os == 'ubuntu-22.04'
     - name: Free Disk Space (Ubuntu)
       uses: jlumbroso/free-disk-space@main
       if: matrix.os == 'ubuntu-22.04'
       with:
         tool-cache: false
-    - name: Install Ninja
-      run: |
-        curl -L -O "https://github.com/ninja-build/ninja/releases/download/v1.12.1/${{ matrix.ninja_file }}" && \
-        ${{ matrix.ninja_sudo }} unzip -o ${{ matrix.ninja_file }} -d ${{ matrix.ninja_dir }} && rm ${{ matrix.ninja_file }}
-      if: matrix.tar != 'osx'
-      shell: bash
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@master
+    - uses: cachix/install-nix-action@v31
       with:
-        toolchain: 1.89.0
+        nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/871b9fd269ff6246794583ce4ee1031e1da71895.tar.gz
     - name: Build
-      run: ./build.sh ${{ matrix.out_dir }}
+      run: ./build.sh --nix ${{ matrix.out_dir }}
       shell: bash
     - name: Upload ${{ matrix.tar }} tarball
       uses: actions/upload-artifact@v4

--- a/build.sh
+++ b/build.sh
@@ -171,7 +171,7 @@ if [[ "${HOST_TRIPLE}" != "x86_64-pc-windows-msvc" ]] ; then
 
     cp -R rust/src/llvm-project/lldb/scripts/solana/* deploy/llvm/bin/
     cp -R rust/build/${HOST_TRIPLE}/llvm/lib/liblldb.* deploy/llvm/lib/
-    if [[ "${WITH_NIX}" != "--nix" && "${HOST_TRIPLE}" == "x86_64-unknown-linux-gnu" || "${HOST_TRIPLE}" == "aarch64-unknown-linux-gnu" ]]; then
+    if [[ "${WITH_NIX}" != "--nix" ]] && [[ "${HOST_TRIPLE}" == "x86_64-unknown-linux-gnu" || "${HOST_TRIPLE}" == "aarch64-unknown-linux-gnu" ]]; then
         cp -R rust/build/${HOST_TRIPLE}/llvm/local/lib/python* deploy/llvm/lib
     else
         cp -R rust/build/${HOST_TRIPLE}/llvm/lib/python* deploy/llvm/lib/

--- a/build.sh
+++ b/build.sh
@@ -73,32 +73,32 @@ rm -rf "${OUT_DIR}"
 mkdir -p "${OUT_DIR}"
 pushd "${OUT_DIR}"
 
-git clone --single-branch --branch mac-mig --recurse-submodules --shallow-submodules https://github.com/joncinque/rust.git
-echo "$( cd rust && git rev-parse HEAD )  https://github.com/anza-xyz/rust.git" >> version.md
+#git clone --single-branch --branch mac-mig --recurse-submodules --shallow-submodules https://github.com/joncinque/rust.git
+#echo "$( cd rust && git rev-parse HEAD )  https://github.com/anza-xyz/rust.git" >> version.md
 
 git clone --single-branch --branch solana-tools-v1.53 https://github.com/anza-xyz/cargo.git
 echo "$( cd cargo && git rev-parse HEAD )  https://github.com/anza-xyz/cargo.git" >> version.md
 
-pushd rust
-if [[ "${HOST_TRIPLE}" == "x86_64-pc-windows-msvc" ]] ; then
+#pushd rust
+#if [[ "${HOST_TRIPLE}" == "x86_64-pc-windows-msvc" ]] ; then
     # Do not build lldb on Windows
-    sed -i -e 's#enable-projects = \"clang;lld;lldb\"#enable-projects = \"clang;lld\"#g' bootstrap.toml
-fi
+#    sed -i -e 's#enable-projects = \"clang;lld;lldb\"#enable-projects = \"clang;lld\"#g' bootstrap.toml
+#fi
 
-if [[ "${HOST_TRIPLE}" == *"apple"* ]]; then
-    ./src/llvm-project/lldb/scripts/macos-setup-codesign.sh
-fi
+#if [[ "${HOST_TRIPLE}" == *"apple"* ]]; then
+#    ./src/llvm-project/lldb/scripts/macos-setup-codesign.sh
+#fi
 
 #./build.sh $WITH_NIX
-popd
+#popd
 
 pushd cargo
 if [[ "${WITH_NIX}" == "--nix" ]] ; then
-    PURE_ARG="--pure"
     if [[ "$(uname)" == "Darwin" ]] ; then
-        PURE_ARG=""
+        nix-shell shell.nix --run "cargo build --release"
+    else
+        nix-shell shell.nix --pure --run "cargo build --release"
     fi
-    nix-shell shell.nix "${PURE_ARG}" --run "cargo build --release"
 else
     if [[ "${HOST_TRIPLE}" == "x86_64-unknown-linux-gnu" ]] ; then
         OPENSSL_STATIC=1 OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu OPENSSL_INCLUDE_DIR=/usr/include/openssl cargo build --release

--- a/build.sh
+++ b/build.sh
@@ -89,12 +89,16 @@ if [[ "${HOST_TRIPLE}" == *"apple"* ]]; then
     ./src/llvm-project/lldb/scripts/macos-setup-codesign.sh
 fi
 
-./build.sh $WITH_NIX
+#./build.sh $WITH_NIX
 popd
 
 pushd cargo
 if [[ "${WITH_NIX}" == "--nix" ]] ; then
-    nix-shell shell.nix --pure --run "cargo build --release"
+    PURE_ARG="--pure"
+    if [[ "$(uname)" == "Darwin" ]] ; then
+        PURE_ARG=""
+    fi
+    nix-shell shell.nix "${PURE_ARG}" --run "cargo build --release"
 else
     if [[ "${HOST_TRIPLE}" == "x86_64-unknown-linux-gnu" ]] ; then
         OPENSSL_STATIC=1 OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu OPENSSL_INCLUDE_DIR=/usr/include/openssl cargo build --release

--- a/build.sh
+++ b/build.sh
@@ -171,7 +171,7 @@ if [[ "${HOST_TRIPLE}" != "x86_64-pc-windows-msvc" ]] ; then
 
     cp -R rust/src/llvm-project/lldb/scripts/solana/* deploy/llvm/bin/
     cp -R rust/build/${HOST_TRIPLE}/llvm/lib/liblldb.* deploy/llvm/lib/
-    if [[ "${HOST_TRIPLE}" == "x86_64-unknown-linux-gnu" || "${HOST_TRIPLE}" == "aarch64-unknown-linux-gnu" ]]; then
+    if [[ "${WITH_NIX}" != "--nix" && "${HOST_TRIPLE}" == "x86_64-unknown-linux-gnu" || "${HOST_TRIPLE}" == "aarch64-unknown-linux-gnu" ]]; then
         cp -R rust/build/${HOST_TRIPLE}/llvm/local/lib/python* deploy/llvm/lib
     else
         cp -R rust/build/${HOST_TRIPLE}/llvm/lib/python* deploy/llvm/lib/

--- a/build.sh
+++ b/build.sh
@@ -73,7 +73,7 @@ rm -rf "${OUT_DIR}"
 mkdir -p "${OUT_DIR}"
 pushd "${OUT_DIR}"
 
-git clone --single-branch --branch solana-tools-v1.53 --recurse-submodules --shallow-submodules https://github.com/anza-xyz/rust.git
+git clone --single-branch --branch mac-mig --recurse-submodules --shallow-submodules https://github.com/joncinque/rust.git
 echo "$( cd rust && git rev-parse HEAD )  https://github.com/anza-xyz/rust.git" >> version.md
 
 git clone --single-branch --branch solana-tools-v1.53 https://github.com/anza-xyz/cargo.git

--- a/build.sh
+++ b/build.sh
@@ -94,11 +94,8 @@ echo "$( cd cargo && git rev-parse HEAD )  https://github.com/anza-xyz/cargo.git
 
 pushd cargo
 if [[ "${WITH_NIX}" == "--nix" ]] ; then
-    if [[ "$(uname)" == "Darwin" ]] ; then
-        nix-shell shell.nix --run "cargo build --release"
-    else
-        nix-shell shell.nix --pure --run "cargo build --release"
-    fi
+    # NIX_SSL_CERT_FILE is required for Mac builds
+    nix-shell shell.nix --pure --keep NIX_SSL_CERT_FILE --run "cargo build --release"
 else
     if [[ "${HOST_TRIPLE}" == "x86_64-unknown-linux-gnu" ]] ; then
         OPENSSL_STATIC=1 OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu OPENSSL_INCLUDE_DIR=/usr/include/openssl cargo build --release

--- a/build.sh
+++ b/build.sh
@@ -1,13 +1,21 @@
 #!/usr/bin/env bash
 set -ex
 
+WITH_NIX=
+case "$1" in
+    --nix)
+        WITH_NIX="--nix"
+        shift
+        ;;
+esac
+
 function build_newlib() {
     mkdir -p newlib_build_"$1"
     mkdir -p newlib_"$1"
     pushd newlib_build_"$1"
 
     local c_flags="-O2"
-    if [[ "$1" != "v0" ]] ; then 
+    if [[ "$1" != "v0" ]] ; then
       c_flags="${c_flags} -mcpu=$1"
     fi
 
@@ -29,7 +37,7 @@ function copy_newlib() {
     mkdir -p deploy/llvm/lib/sbpf"${folder_name}"
     mkdir -p deploy/llvm/sbpf"${folder_name}"
     cp -R newlib_"$1"/sbf-solana/lib/lib{c,m}.a deploy/llvm/lib/sbpf"${folder_name}"/
-    cp -R newlib_"$1"/sbf-solana/include deploy/llvm/sbpf"${folder_name}"/    
+    cp -R newlib_"$1"/sbf-solana/include deploy/llvm/sbpf"${folder_name}"/
 }
 
 unameOut="$(uname -s)"
@@ -81,14 +89,18 @@ if [[ "${HOST_TRIPLE}" == *"apple"* ]]; then
     ./src/llvm-project/lldb/scripts/macos-setup-codesign.sh
 fi
 
-./build.sh
+./build.sh $WITH_NIX
 popd
 
 pushd cargo
-if [[ "${HOST_TRIPLE}" == "x86_64-unknown-linux-gnu" ]] ; then
-    OPENSSL_STATIC=1 OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu OPENSSL_INCLUDE_DIR=/usr/include/openssl cargo build --release
+if [[ "${WITH_NIX}" == "--nix" ]] ; then
+    nix-shell shell.nix --pure --run "cargo build --release"
 else
-    OPENSSL_STATIC=1 cargo build --release
+    if [[ "${HOST_TRIPLE}" == "x86_64-unknown-linux-gnu" ]] ; then
+        OPENSSL_STATIC=1 OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu OPENSSL_INCLUDE_DIR=/usr/include/openssl cargo build --release
+    else
+        OPENSSL_STATIC=1 cargo build --release
+    fi
 fi
 popd
 
@@ -150,7 +162,7 @@ cp -R "rust/build/${HOST_TRIPLE}/llvm/build/lib/clang" deploy/llvm/lib/
 if [[ "${HOST_TRIPLE}" != "x86_64-pc-windows-msvc" ]] ; then
     cp -R newlib_v0/sbf-solana/lib/lib{c,m}.a deploy/llvm/lib/
     cp -R newlib_v0/sbf-solana/include deploy/llvm/
-    
+
     copy_newlib "v0"
     copy_newlib "v1"
     copy_newlib "v2"

--- a/build.sh
+++ b/build.sh
@@ -170,11 +170,11 @@ if [[ "${HOST_TRIPLE}" != "x86_64-pc-windows-msvc" ]] ; then
 
     cp -R rust/src/llvm-project/lldb/scripts/solana/* deploy/llvm/bin/
     cp -R rust/build/${HOST_TRIPLE}/llvm/lib/liblldb.* deploy/llvm/lib/
-    if [[ "${HOST_TRIPLE}" == "x86_64-unknown-linux-gnu" || "${HOST_TRIPLE}" == "aarch64-unknown-linux-gnu" ]]; then
-        cp -R rust/build/${HOST_TRIPLE}/llvm/local/lib/python* deploy/llvm/lib
-    else
-        cp -R rust/build/${HOST_TRIPLE}/llvm/lib/python* deploy/llvm/lib/
-    fi
+    #if [[ "${HOST_TRIPLE}" == "x86_64-unknown-linux-gnu" || "${HOST_TRIPLE}" == "aarch64-unknown-linux-gnu" ]]; then
+        #cp -R rust/build/${HOST_TRIPLE}/llvm/local/lib/python* deploy/llvm/lib
+    #else
+        #cp -R rust/build/${HOST_TRIPLE}/llvm/lib/python* deploy/llvm/lib/
+    #fi
 fi
 
 # Check the Rust binaries

--- a/build.sh
+++ b/build.sh
@@ -73,24 +73,24 @@ rm -rf "${OUT_DIR}"
 mkdir -p "${OUT_DIR}"
 pushd "${OUT_DIR}"
 
-#git clone --single-branch --branch mac-mig --recurse-submodules --shallow-submodules https://github.com/joncinque/rust.git
-#echo "$( cd rust && git rev-parse HEAD )  https://github.com/anza-xyz/rust.git" >> version.md
+git clone --single-branch --branch mac-mig --recurse-submodules --shallow-submodules https://github.com/joncinque/rust.git
+echo "$( cd rust && git rev-parse HEAD )  https://github.com/anza-xyz/rust.git" >> version.md
 
 git clone --single-branch --branch solana-tools-v1.53 https://github.com/anza-xyz/cargo.git
 echo "$( cd cargo && git rev-parse HEAD )  https://github.com/anza-xyz/cargo.git" >> version.md
 
-#pushd rust
-#if [[ "${HOST_TRIPLE}" == "x86_64-pc-windows-msvc" ]] ; then
+pushd rust
+if [[ "${HOST_TRIPLE}" == "x86_64-pc-windows-msvc" ]] ; then
     # Do not build lldb on Windows
-#    sed -i -e 's#enable-projects = \"clang;lld;lldb\"#enable-projects = \"clang;lld\"#g' bootstrap.toml
-#fi
+    sed -i -e 's#enable-projects = \"clang;lld;lldb\"#enable-projects = \"clang;lld\"#g' bootstrap.toml
+fi
 
-#if [[ "${HOST_TRIPLE}" == *"apple"* ]]; then
-#    ./src/llvm-project/lldb/scripts/macos-setup-codesign.sh
-#fi
+if [[ "${HOST_TRIPLE}" == *"apple"* ]]; then
+    ./src/llvm-project/lldb/scripts/macos-setup-codesign.sh
+fi
 
-#./build.sh $WITH_NIX
-#popd
+./build.sh $WITH_NIX
+popd
 
 pushd cargo
 if [[ "${WITH_NIX}" == "--nix" ]] ; then
@@ -171,11 +171,11 @@ if [[ "${HOST_TRIPLE}" != "x86_64-pc-windows-msvc" ]] ; then
 
     cp -R rust/src/llvm-project/lldb/scripts/solana/* deploy/llvm/bin/
     cp -R rust/build/${HOST_TRIPLE}/llvm/lib/liblldb.* deploy/llvm/lib/
-    #if [[ "${HOST_TRIPLE}" == "x86_64-unknown-linux-gnu" || "${HOST_TRIPLE}" == "aarch64-unknown-linux-gnu" ]]; then
-        #cp -R rust/build/${HOST_TRIPLE}/llvm/local/lib/python* deploy/llvm/lib
-    #else
-        #cp -R rust/build/${HOST_TRIPLE}/llvm/lib/python* deploy/llvm/lib/
-    #fi
+    if [[ "${HOST_TRIPLE}" == "x86_64-unknown-linux-gnu" || "${HOST_TRIPLE}" == "aarch64-unknown-linux-gnu" ]]; then
+        cp -R rust/build/${HOST_TRIPLE}/llvm/local/lib/python* deploy/llvm/lib
+    else
+        cp -R rust/build/${HOST_TRIPLE}/llvm/lib/python* deploy/llvm/lib/
+    fi
 fi
 
 # Check the Rust binaries

--- a/build.sh
+++ b/build.sh
@@ -73,7 +73,7 @@ rm -rf "${OUT_DIR}"
 mkdir -p "${OUT_DIR}"
 pushd "${OUT_DIR}"
 
-git clone --single-branch --branch mac-mig --recurse-submodules --shallow-submodules https://github.com/joncinque/rust.git
+git clone --single-branch --branch solana-tools-v1.53 --recurse-submodules --shallow-submodules https://github.com/anza-xyz/rust.git
 echo "$( cd rust && git rev-parse HEAD )  https://github.com/anza-xyz/rust.git" >> version.md
 
 git clone --single-branch --branch solana-tools-v1.53 https://github.com/anza-xyz/cargo.git

--- a/build.sh
+++ b/build.sh
@@ -73,10 +73,10 @@ rm -rf "${OUT_DIR}"
 mkdir -p "${OUT_DIR}"
 pushd "${OUT_DIR}"
 
-git clone --single-branch --branch solana-tools-v1.53 --recurse-submodules --shallow-submodules https://github.com/anza-xyz/rust.git
+git clone --single-branch --branch solana-tools-v1.54 --recurse-submodules --shallow-submodules https://github.com/anza-xyz/rust.git
 echo "$( cd rust && git rev-parse HEAD )  https://github.com/anza-xyz/rust.git" >> version.md
 
-git clone --single-branch --branch solana-tools-v1.53 https://github.com/anza-xyz/cargo.git
+git clone --single-branch --branch solana-tools-v1.54 https://github.com/anza-xyz/cargo.git
 echo "$( cd cargo && git rev-parse HEAD )  https://github.com/anza-xyz/cargo.git" >> version.md
 
 pushd rust
@@ -106,7 +106,7 @@ fi
 popd
 
 if [[ "${HOST_TRIPLE}" != "x86_64-pc-windows-msvc" ]] ; then
-    git clone --single-branch --branch solana-tools-v1.53 https://github.com/anza-xyz/newlib.git
+    git clone --single-branch --branch solana-tools-v1.54 https://github.com/anza-xyz/newlib.git
     echo "$( cd newlib && git rev-parse HEAD )  https://github.com/anza-xyz/newlib.git" >> version.md
 
     build_newlib "v0"


### PR DESCRIPTION
#### Problem

The current build scripts run as normal commands in CI machines, which means that certain shared libraries are linked into binaries. For the most part, this is fine, but some binaries, such as `solana-lldb`, have a few extra shared libs:

```
~/.c/s/v/p/l/bin> ldd lldb
        linux-vdso.so.1 (0x00007fea34cba000)
        liblldb.so.19.1-rust-dev => /home/jon/.cache/solana/v1.51/platform-tools/llvm/bin/../lib/liblldb.so.19.1-rust-dev (0x00007fea2dc00000)
        libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x00007fea2d800000)
        libm.so.6 => /usr/lib/libm.so.6 (0x00007fea2daf2000)
        libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x00007fea2dac5000)
        libc.so.6 => /usr/lib/libc.so.6 (0x00007fea2d400000)
        /lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2 (0x00007fea34cbc000)
        libpython3.10.so.1.0 => not found
        libpanel.so.6 => not found
        libncurses.so.6 => not found
        libtinfo.so.6 => /usr/lib/libtinfo.so.6 (0x00007fea2d791000)
        libxml2.so.2 => /usr/lib/libxml2.so.2 (0x00007fea2d643000)
        libedit.so.2 => not found
        liblzma.so.5 => /usr/lib/liblzma.so.5 (0x00007fea2d3cc000)
        libz.so.1 => /usr/lib/libz.so.1 (0x00007fea2daac000)
        libicuuc.so.76 => /usr/lib/libicuuc.so.76 (0x00007fea2d000000)
        libicudata.so.76 => /usr/lib/libicudata.so.76 (0x00007fea2b000000)
```

On my local machine, you'll see that a few of these libraries aren't found. This isn't a good experience for users.

Also, when packaging the platform tools for nix, we have to do a lot of extra patching:

https://github.com/arijoon/solana-nix/blob/65a7cc4a9fff662fc6077b8b49bca6d3c96883c8/solana-platform-tools.nix#L92

#### Summary of changes

Build rust and cargo using nix, which statically links a lot of these dependencies. This mostly impacts llvm bins, and the size for all bins is roughly the same. Some are slightly bigger or smaller, within 1% of the size.