### PR TITLE
Revert "Bump tools version to v1.55 (#115)"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: 1.95.0
+        toolchain: 1.89.0
     - name: Build
       run: ./build.sh ${{ matrix.out_dir }}
       shell: bash

--- a/build.sh
+++ b/build.sh
@@ -65,16 +65,16 @@ rm -rf "${OUT_DIR}"
 mkdir -p "${OUT_DIR}"
 pushd "${OUT_DIR}"
 
-git clone --single-branch --branch solana-tools-v1.55 --recurse-submodules --shallow-submodules https://github.com/anza-xyz/rust.git
+git clone --single-branch --branch solana-tools-v1.54 --recurse-submodules --shallow-submodules https://github.com/anza-xyz/rust.git
 echo "$( cd rust && git rev-parse HEAD )  https://github.com/anza-xyz/rust.git" >> version.md
 
-git clone --single-branch --branch solana-tools-v1.55 https://github.com/anza-xyz/cargo.git
+git clone --single-branch --branch solana-tools-v1.54 https://github.com/anza-xyz/cargo.git
 echo "$( cd cargo && git rev-parse HEAD )  https://github.com/anza-xyz/cargo.git" >> version.md
 
 pushd rust
 if [[ "${HOST_TRIPLE}" == "x86_64-pc-windows-msvc" ]] ; then
     # Do not build lldb on Windows
-    sed -i -e 's#enable-projects = \"lld;lldb\"#enable-projects = \"lld\"#g' bootstrap.toml
+    sed -i -e 's#enable-projects = \"clang;lld;lldb\"#enable-projects = \"clang;lld\"#g' bootstrap.toml
 fi
 
 if [[ "${HOST_TRIPLE}" == *"apple"* ]]; then
@@ -93,7 +93,7 @@ fi
 popd
 
 if [[ "${HOST_TRIPLE}" != "x86_64-pc-windows-msvc" ]] ; then
-    git clone --single-branch --branch solana-tools-v1.55 https://github.com/anza-xyz/newlib.git
+    git clone --single-branch --branch solana-tools-v1.54 https://github.com/anza-xyz/newlib.git
     echo "$( cd newlib && git rev-parse HEAD )  https://github.com/anza-xyz/newlib.git" >> version.md
 
     build_newlib "v0"
@@ -131,7 +131,7 @@ clang
 clang++
 clang-cl
 clang-cpp
-clang-22
+clang-20
 ld.lld
 ld64.lld
 llc


### PR DESCRIPTION
Because we've found two bugs in Rust 1.89, I'll revert the bump to 1.95 and release an extra version of 1.89 with https://github.com/anza-xyz/rust/pull/154 before releasing 1.95.

This reverts commit d3c2ea42e40b30ed14ce5a3947be38637b0aa82c.